### PR TITLE
[zorg] Avoid usage of old removed API when migrating on Buildbot 3.3.x.

### DIFF
--- a/zorg/buildbot/commands/LitTestCommand.py
+++ b/zorg/buildbot/commands/LitTestCommand.py
@@ -159,9 +159,8 @@ class LitTestCommand(Test):
                *args, **kwargs):
     super().__init__(*args, **kwargs)
     self.maxLogs = int(max_logs)
-    self.logObserver = LitLogObserver(self.maxLogs, parseSummaryOnly)
-    self.addFactoryArguments(max_logs=max_logs)
-    self.addFactoryArguments(parseSummaryOnly=parseSummaryOnly)
+    self.parseSummaryOnly = parseSummaryOnly
+    self.logObserver = LitLogObserver(self.maxLogs, self.parseSummaryOnly)
     self.addLogObserver('stdio', self.logObserver)
 
   def evaluateCommand(self, cmd):

--- a/zorg/buildbot/util/phasedbuilderutils.py
+++ b/zorg/buildbot/util/phasedbuilderutils.py
@@ -20,8 +20,7 @@ class NamedTrigger(Trigger):
         Trigger.__init__(self, **kwargs)
         self.name = name
         self.triggeredBuilders = triggeredBuilders
-        self.addFactoryArguments(name = name,
-                                 triggeredBuilders = triggeredBuilders)
+
     def start(self):
         # Add a log linking to the triggered builders, if supplied.
         if self.triggeredBuilders:


### PR DESCRIPTION
The `BuildStep.addFactoryArguments` API method has been removed from Buildbot 3.x. Avoid usage of these methods.