### PR TITLE
[config] Ported notifiers initialization to Buildbot 3.x.

### DIFF
--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -1,20 +1,36 @@
 from buildbot.process.properties import Interpolate
 from buildbot.plugins import reporters
+from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
+from buildbot.reporters.message import MessageFormatterRenderable
+from twisted.python import log
 
 import config
-from zorg.buildbot.util.InformativeMailNotifier import LLVMInformativeMailNotifier
+from zorg.buildbot.util.InformativeMailNotifier import (
+    LLVMInformativeMailGenerator,
+    LLVMDefaultBuildStatusGenerator
+)
 
-# Should be a single e-mail address
 status_email = str(config.options.get('Master Options', 'status_email')).split(',')
 
-all = [
+# Should be a single e-mail address
+status_email_fromaddr = str(config.options.get('Master Options', 'status_email_fromaddr',
+                            fallback='llvm.buildmaster@lab.llvm.org'))
 
+all = []
+
+if config.options.has_option('GitHub Status', 'token'):
+    start_formatter = MessageFormatterRenderable('Build started.')
+    end_formatter = MessageFormatterRenderable('Build done.')
+    all.append(
     # Report github status for all the release builders,
     # i.e. those with the "release" tag.
     reporters.GitHubStatusPush(
         str(config.options.get('GitHub Status', 'token')),
         context = Interpolate("%(prop:buildername)s"),
         verbose = True, # TODO: Turn off the verbosity once this is working reliably.
+        generators = [BuildStartEndStatusGenerator(
+            start_formatter = start_formatter,
+            end_formatter = end_formatter,
         builders = [
                 "llvm-clang-x86_64-expensive-checks-ubuntu",
                 "llvm-clang-x86_64-win-fast",
@@ -23,10 +39,19 @@ all = [
                 "llvm-clang-x86_64-sie-ubuntu-fast",
             ] + [
                 b.get('name') for b in config.release_builders.all
-                if 'release' in b.get('tags', [])
+                # Note master.cfg adds the tag 'release' to release_builders.all
+                # for all builders. No need to check it here.
+                # Otherwise it must be fixed because this code is executed
+                # before adding the tag 'release' in master.cfg.
+                # if 'release' in b.get('tags', [])
             ]
         ),
+        ]))
+else:
+    log.msg("Warning: No 'GitHub Status' notifier has been configured.")
 
+if config.options.has_section("IRC"):
+    all.append(
     reporters.IRC(
         useColors = False,
         host = str(config.options.get('IRC', 'host')),
@@ -36,154 +61,156 @@ all = [
         useRevisions = False, # FIXME: There is a bug in the buildbot
         showBlameList = True,
         notify_events = str(config.options.get('IRC', 'notify_events')).split(','),
-        ),
+    ))
+else:
+    log.msg("Warning: No 'IRC' notifier has been configured.")
 
+all.extend([
     reporters.MailNotifier(
-        mode = ('problem',),
-        fromaddr = "llvm.buildmaster@lab.llvm.org", # TODO: Change this to buildmaster@lab.llvm.org.
+        fromaddr = status_email_fromaddr,
         extraRecipients = status_email,
         extraHeaders = {"Reply-To": status_email[0]}, # The first from the list.
         lookup = "lab.llvm.org",
-        messageFormatter = LLVMInformativeMailNotifier,
         # TODO: For debug purposes only. Remove later.
         dumpMailsToLog = True,
+        generators = [LLVMInformativeMailGenerator(
         builders = [
                 b.get('name') for b in config.builders.all
                 if 'silent' not in b.get('tags', [])
             ]
         ),
-
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["gribozavr@gmail.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-x86_64-debian-fast"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["tbaeder@redhat.com", "tstellar@redhat.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["llvm-x86_64-debian-dylib"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["llvm.buildmaster@quicinc.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-hexagon-elf"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["Ulrich.Weigand@de.ibm.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-s390x-linux", "clang-s390x-linux-multistage",
                     "clang-s390x-linux-lnt", "mlir-s390x-linux"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["sunil_srivastava@playstation.sony.com",
                             "warren_ristow@playstation.sony.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-x86_64-linux-abi-test"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["gkistanova@gmail.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["lld-x86_64-win",
                     "lld-x86_64-freebsd",
                     "clang-x86_64-linux-abi-test",
                     "clang-with-lto-ubuntu", "clang-with-thin-lto-ubuntu",
                     "llvm-clang-x86_64-expensive-checks-win",
                     "llvm-clang-x86_64-expensive-checks-ubuntu"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["efriedma@codeaurora.org", "huihuiz@codeaurora.org"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["polly-arm-linux",
                     "aosp-O3-polly-before-vectorizer-unprofitable"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["mgrang@codeaurora.org"],
-        subject = "Build %(builder)s Failure",
+        generators = [LLVMDefaultBuildStatusGenerator(
         mode = "problem",
         builders = ["reverse-iteration"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["tra+buildbot@google.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-cuda-k80", "clang-cuda-p4", "clang-cuda-t4"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["asb@lowrisc.org"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["llvm-riscv-linux"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["aifxbuildbotdri@microsoft.com", "namcvica@microsoft.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["mlir-windows"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["gongsu@us.ibm.com", "alexe@us.ibm.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["mlir-s390x-linux-werror"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["phosek@google.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["fuchsia-x86_64-linux"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["labath@google.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["lldb-x86_64-debian"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["vvereschaka@accesssoftek.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["llvm-clang-x86_64-win-fast","lld-x86_64-ubuntu-fast",
                     "llvm-clang-x86_64-expensive-checks-ubuntu",
                     "llvm-clang-win-x-armv7l", "llvm-clang-win-x-aarch64",
                     "llvm-nvptx-nvidia-ubuntu", "llvm-nvptx64-nvidia-ubuntu",
                     "llvm-nvptx-nvidia-win", "llvm-nvptx64-nvidia-win"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["llvm.buildbot@emea.nec.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-ve-ninja"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["lntue@google.com", "michaelrj@google.com",
                            "sivachandra@google.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["libc-x86_64-debian", "libc-x86_64_debian-dbg",
                     "libc-x86_64-debian-dbg-runtimes-build",
                     "libc-x86_64-debian-dbg-asan", "libc-aarch64-ubuntu-dbg",
@@ -195,36 +222,39 @@ all = [
                     "libc-riscv64-debian-dbg",
                     "libc-riscv64-debian-fullbuild-dbg",
                     "libc-x86_64-debian-dbg-lint"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["aaron@aaronballman.com"],
+        generators = [LLVMDefaultBuildStatusGenerator(
         subject = "Sphinx build %(builder)s Failure",
-        mode = "failing",
         builders = ["publish-sphinx-docs"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=[
             "mlcompileropt-buildbot@google.com"],
+        generators = [LLVMDefaultBuildStatusGenerator(
         subject = "ML Compiler Opt Failure: %(builder)s",
-        mode = "failing",
         builders = [
             "ml-opt-dev-x86-64", "ml-opt-rel-x86-64", "ml-opt-devrel-x86-64"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=[
             "tejohnson@google.com"],
+        generators = [LLVMDefaultBuildStatusGenerator(
         subject = "ThinLTO WPD Failure: %(builder)s",
-        mode = "failing",
         builders = ["clang-with-thin-lto-wpd-ubuntu"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["douglas.yung@sony.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["llvm-clang-x86_64-sie-ubuntu-fast",
                     "llvm-clang-x86_64-sie-win",
                     "llvm-clang-x86_64-sie-win-release",
@@ -232,81 +262,86 @@ all = [
                     "llvm-clang-x86_64-gcc-ubuntu-release",
                     "cross-project-tests-sie-ubuntu",
                     "cross-project-tests-sie-ubuntu-dwarf5"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["tom.weaver@sony.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["llvm-clang-x86_64-sie-ubuntu-fast",
                     "llvm-clang-x86_64-sie-win",
                     "llvm-clang-x86_64-gcc-ubuntu"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=[
             "joker.eph@gmail.com"],
+        generators = [LLVMDefaultBuildStatusGenerator(
         subject = "MLIR Build Failure: %(builder)s",
-        mode = "failing",
         builders = ["mlir-nvidia"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=[
             "mlir-bugs-external+buildbot@googlegroups.com"],
+        generators = [LLVMDefaultBuildStatusGenerator(
         subject = "MLIR Build Failure: %(builder)s",
-        mode = "failing",
         builders = ["mlir-nvidia",
                     "mlir-windows",
                     "ppc64le-mlir-rhel-clang"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=["dl.gcr.lightning.buildbot@amd.com"],
-        subject = "Build Failure: %(builder)s",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-hip-vega20"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=["llvm_arc_buildbot@synopsys.com", "heli@synopsys.com"],
-        subject = "Build Failure: %(builder)s",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["arc-builder"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=["dl.gcr.lightning.buildbot@amd.com"],
-        subject = "Build Failure: %(builder)s",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["openmp-offload-amdgpu-runtime"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=["dl.mlse.buildbot@amd.com"],
-        subject = "Build Failure: %(builder)s",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["mlir-rocm-mi200"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=["flangbuilder@meinersbur.de"],
+        generators = [LLVMDefaultBuildStatusGenerator(
         subject = "Build Failure (flang): %(builder)s",
-        mode = "failing",
         builders = ["flang-x86_64-windows"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=["offloadbuilder@meinersbur.de"],
+        generators = [LLVMDefaultBuildStatusGenerator(
         subject = "Build Failure (offload): %(builder)s",
-        mode = "failing",
         builders = ["openmp-offload-cuda-project","openmp-offload-cuda-runtime"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr="llvm.buildmaster@lab.llvm.org",
+        fromaddr=status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients=["pollybuilder@meinersbur.de"],
+        generators = [LLVMDefaultBuildStatusGenerator(
         subject = "Build Failure (polly): %(builder)s",
-        mode = "failing",
         builders = [
                 "polly-x86_64-linux",
                 "polly-x86_64-linux-noassert",
@@ -317,66 +352,68 @@ all = [
                 "polly-x86_64-linux-shlib-plugin",
                 "polly-sphinx-docs",
             ]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["orlando.hyams@sony.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["cross-project-tests-sie-ubuntu",
                     "llvm-clang-x86_64-sie-win"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["kkleine@redhat.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["standalone-build-x86_64"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["llvm-bolt@meta.com"],
+        generators = [LLVMDefaultBuildStatusGenerator(
         subject = "BOLT NFC checks mismatch",
         mode = ("warnings",),
         builders = ["bolt-x86_64-ubuntu-nfc"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["luweining@loongson.cn", "chenli@loongson.cn"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-loongarch64-linux"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["kadircet@google.com", "sammccall@google.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clangd-ubuntu-tsan"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["kadircet@google.com", "ibiryukov@google.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-debian-cpp20"]),
+        ]),
     reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
+        fromaddr = status_email_fromaddr,
         sendToInterestedUsers = False,
         extraRecipients = ["llvm.buildbot.notification@intel.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
+        generators = [LLVMDefaultBuildStatusGenerator(
         builders = ["clang-cmake-x86_64-avx512-linux"]),
-]
+        ]),
+])
 
-
-from twisted.python import log
 
 # Returns a list of Status Targets. The results of each build will be
 # pushed to these targets. buildbot.plugins reporters has a variety
 # to choose from, including email senders, and IRC bots.
 def getReporters():
-    if config.options.getboolean('Master Options', 'is_production'):
+    # Staging buildbot by default.
+    if config.options.getboolean('Master Options', 'is_production', fallback=False):
         log.msg(">>> getReporters: Production mode. All reporters are registered.")
         return all
     else:


### PR DESCRIPTION
BB 3.x requires passing a list of builders to the notifiers through the status generators. The notifier initialization has been updated accordingly.

Also added a new local configuration option status_email_fromaddr within the Master Options section. This option must be set with an appropriate e-mail address (llvm.buildmaster@lab.llvm.org or buildmaster@lab.llvm.org).

Based on https://github.com/gkistanova/llvm-zorg/pull/5

Depends on https://github.com/gkistanova/llvm-zorg/pull/7

Note a wrong formatting to minimize diff. The proper formatting is required as a separate commit.