### PR TITLE
Fixed the step setproperty for MSVCBuildFactory

### DIFF
--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -366,7 +366,7 @@ def getCmakeWithNinjaWithMSVCBuildFactory(
     f.addStep(SetPropertyFromCommand(
         command=builders_util.getVisualStudioEnvironment(vs, target_arch),
         extract_fn=builders_util.extractVSEnvironment,
-        env=env))
+        env=env or {}))
     env = util.Property('vs_env')
 
     cleanBuildRequested = lambda step: step.build.getProperty("clean", default=step.build.getProperty("clean_obj")) or clean


### PR DESCRIPTION
Fixed the following exception when `env` is not defined 
```
File "buildbot/master/buildbot/process/buildstep.py", line 922, in makeRemoteShellCommand 
kwargs['env'] = {
builtins.TypeError: 'NoneType' object is not a mapping
```