### PR TITLE
Add consolidated build factory generator for the LLVM unified tree builds.

### DIFF
--- a/test/buildbot/builders/unified_cmakeex.py
+++ b/test/buildbot/builders/unified_cmakeex.py
@@ -1,0 +1,352 @@
+# RUN: python %s
+
+# Lit Regression Tests for UnifiedTreeBuilder.getCmakeExBuildFactory factory.
+
+import sys
+
+from buildbot.plugins import steps
+import buildbot.process.properties
+
+import zorg
+from zorg.buildbot.builders import UnifiedTreeBuilder
+from zorg.buildbot.process.factory import LLVMBuildFactory
+
+def partly_rendered(r):
+    if isinstance(r, buildbot.process.properties.Interpolate):
+        interpolations = {}
+        for k, v in r.kwargs.items():
+            interpolations[f"kw:{k}"] = v
+        return r.fmtstring % interpolations
+    elif type(r) == str:
+        return r
+
+    return "unsupported_rendering"
+
+def factory_has_num_steps(f, expected_num):
+    assert f
+    if len(f.steps) != expected_num:
+        print(f"error: factory_has_num_steps: {len(f.steps)}, expected {expected_num}")
+    return len(f.steps) == expected_num
+
+def factory_has_step(f, name, hasarg=None, contains=None):
+    assert f
+    assert name
+
+    result = False
+
+    for s in f.steps:
+        v = partly_rendered(s.kwargs.get("name"))
+        if v == name:
+            result = True
+            # check that the step has that argument
+            arg_value = None
+            if hasarg:
+                if not hasarg in s.kwargs:
+                    print(f"error: step '{v}': missing expected step argument '{hasarg}'")
+                    return False
+
+                arg_value = s.kwargs.get(hasarg)
+
+            # Check for contained content if requested.
+            if arg_value and contains:
+                if type(contains) == type(arg_value) == dict:
+                    result = contains.items() <= arg_value.items()
+                elif type(contains) == type(arg_value) == list:
+                    result = contains <= arg_value
+                elif type(contains) == type(arg_value):
+                    result = contains == arg_value
+                else:
+                    print(f"error: step '{v}', argument '{hasarg}': unsupported type to compare, expected is '{type(contains)}', actual is '{type(arg_value)}'")
+                    return False
+
+                if not result:
+                    print(f"error: step '{v}', argument '{hasarg}': expected\n\t{contains}\nactual:\n\t{arg_value}")
+
+            return result
+
+    print(f"error: missing expected step '{name}'")
+
+    return False
+
+DEFAULT_ENV = {'TERM': 'dumb', 'NINJA_STATUS': '%e [%u/%r/%f] '}
+
+# Use all defaults.
+f = UnifiedTreeBuilder.getCmakeExBuildFactory()
+print(f"default factory: {f}\n")
+
+assert len(f.depends_on_projects) == 1
+assert "llvm" in f.depends_on_projects
+assert len(f.enable_runtimes) == 0
+assert len(f.enable_projects) == 1
+assert "llvm" in f.enable_projects
+assert f.monorepo_dir == "llvm-project"
+assert f.src_to_build_dir == "llvm"
+assert f.obj_dir == "build"
+assert f.install_dir is None
+assert f.llvm_srcdir == "llvm-project/llvm"
+assert f.repourl_prefix == "https://github.com/llvm/"
+
+assert factory_has_num_steps(f, 7)
+assert factory_has_step(f, "set-props")
+assert factory_has_step(f, "clean-src-dir")
+assert factory_has_step(f, "clean-obj-dir")
+assert factory_has_step(f, "Checkout the source code")
+
+assert factory_has_step(f, "cmake-configure")
+assert factory_has_step(f, "cmake-configure", hasarg = "generator", contains = "Ninja")
+assert factory_has_step(f, "cmake-configure", hasarg = "definitions", contains = {
+                                                                        'LLVM_ENABLE_PROJECTS'      : 'llvm',
+                                                                        'CMAKE_BUILD_TYPE'          : 'Release',
+                                                                        'LLVM_ENABLE_ASSERTIONS'    : 'ON',
+                                                                        'LLVM_LIT_ARGS'             : '-v --time-tests'
+                                                                    })
+assert factory_has_step(f, "cmake-configure", hasarg = "options", contains = {})
+assert factory_has_step(f, "cmake-configure", hasarg = "env", contains = DEFAULT_ENV)
+
+assert factory_has_step(f, "build-default")
+assert factory_has_step(f, "build-default", hasarg = 'options', contains = ['--build', '.'])
+assert factory_has_step(f, "build-default", hasarg = "env", contains = DEFAULT_ENV)
+assert factory_has_step(f, "test-check-all")
+assert factory_has_step(f, "test-check-all", hasarg = "env", contains = DEFAULT_ENV)
+
+# Change argument dirs
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(
+        llvm_srcdir = "my-llvm-project",
+        src_to_build_dir = "llvmex",
+        obj_dir = "obj.build",
+    )
+print(f"Updated some arg dirs: {f}\n")
+
+assert f.monorepo_dir == "my-llvm-project"
+assert f.src_to_build_dir == "llvmex"
+assert f.obj_dir == "obj.build"
+assert f.install_dir is None
+assert f.llvm_srcdir == "my-llvm-project/llvmex"
+
+assert factory_has_num_steps(f, 7)
+
+assert factory_has_step(f, "cmake-configure", hasarg = "path", contains = "../my-llvm-project/llvmex")
+assert factory_has_step(f, "cmake-configure", hasarg = "workdir", contains = "obj.build")
+
+# Check depends_on_projects/enable_runtimes
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(
+        depends_on_projects = ["llvm", "clang"],
+        #enable_runtimes = "auto",
+    )
+print(f"Check depended projects (1): {f}\n")
+
+assert len(f.depends_on_projects) == 2
+assert "llvm" in f.depends_on_projects
+assert "clang" in f.depends_on_projects
+assert len(f.enable_runtimes) == 0
+assert len(f.enable_projects) == 2
+assert "llvm" in f.enable_projects
+assert "clang" in f.enable_projects
+
+assert factory_has_step(f, "cmake-configure", hasarg = "definitions", contains = {
+                                                                        'LLVM_ENABLE_PROJECTS'      : 'clang;llvm',
+                                                                    })
+
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(
+        depends_on_projects = ["llvm", "clang", "compiler-rt", "libcxx"],
+        #enable_runtimes = "auto",
+    )
+print(f"Check depended projects (2): {f}\n")
+
+assert len(f.depends_on_projects) == 4
+assert "llvm" in f.depends_on_projects
+assert "clang" in f.depends_on_projects
+assert "compiler-rt" in f.depends_on_projects
+assert "libcxx" in f.depends_on_projects
+assert len(f.enable_runtimes) == 2
+assert len(f.enable_projects) == 2
+assert "llvm" in f.enable_projects
+assert "clang" in f.enable_projects
+assert "compiler-rt" in f.enable_runtimes
+assert "libcxx" in f.enable_runtimes
+
+assert factory_has_step(f, "cmake-configure", hasarg = "definitions", contains = {
+                                                                        'LLVM_ENABLE_PROJECTS'      : 'clang;llvm',
+                                                                        'LLVM_ENABLE_RUNTIMES'      : 'compiler-rt;libcxx',
+                                                                    })
+
+# With installation prefix and custom build/test targets
+EXPECTED_ENV = {'TERM': 'vt100', 'HOST_ID': 'DEMO11', 'NINJA_STATUS': '%e [%u/%r/%f] '}
+
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(
+        install_dir = "install-staged",
+        targets = ["clang", "flang", "libunwind"],
+        checks = ["check-clang", "check-flang"],
+        checks_on_target = [
+            ("libunwind",
+                ["python", "bin/llvm-lit.py", "-v", "--time-tests", "--threads=32",
+                    "runtimes/runtimes-armv7-unknown-linux-gnueabihf-bins/libunwind/test"]
+            ),
+        ],
+        env = {'TERM': 'vt100', 'HOST_ID': 'DEMO11'},
+    )
+print(f"factory with install prefix: {f}\n")
+
+assert f.install_dir == "install-staged"
+
+assert factory_has_num_steps(f, 13)
+assert factory_has_step(f, "set-props")
+assert factory_has_step(f, "clean-src-dir")
+assert factory_has_step(f, "clean-obj-dir")
+assert factory_has_step(f, "Checkout the source code")
+
+assert factory_has_step(f, "clean-install-dir")
+assert factory_has_step(f, "cmake-configure")
+assert factory_has_step(f, "cmake-configure", hasarg = "definitions", contains = {
+                                                                        'LLVM_ENABLE_PROJECTS'      : 'llvm',
+                                                                        'CMAKE_BUILD_TYPE'          : 'Release',
+                                                                        'LLVM_ENABLE_ASSERTIONS'    : 'ON',
+                                                                        'LLVM_LIT_ARGS'             : '-v --time-tests',
+                                                                        'CMAKE_INSTALL_PREFIX'      : '../install-staged',
+                                                                    })
+assert factory_has_step(f, "cmake-configure", hasarg = "options", contains = {})
+assert factory_has_step(f, "build-clang")
+assert factory_has_step(f, "build-clang", hasarg = 'options', contains = ['--build', '.', '--target', 'clang'])
+assert factory_has_step(f, "build-clang", hasarg = "env", contains = EXPECTED_ENV)
+assert factory_has_step(f, "build-flang")
+assert factory_has_step(f, "build-flang", hasarg = 'options', contains = ['--build', '.', '--target', 'flang'])
+assert factory_has_step(f, "build-flang", hasarg = "env", contains = EXPECTED_ENV)
+assert factory_has_step(f, "build-libunwind")
+assert factory_has_step(f, "build-libunwind", hasarg = 'options', contains = ['--build', '.', '--target', 'libunwind'])
+assert factory_has_step(f, "build-libunwind", hasarg = "env", contains = EXPECTED_ENV)
+assert factory_has_step(f, "test-check-clang")
+assert factory_has_step(f, "test-check-clang", hasarg = 'command', contains = ['--build', '.', '--target', 'check-clang'])
+assert factory_has_step(f, "test-check-clang", hasarg = "env", contains = EXPECTED_ENV)
+assert factory_has_step(f, "test-check-flang")
+assert factory_has_step(f, "test-check-flang", hasarg = 'command', contains = ['--build', '.', '--target', 'check-flang'])
+assert factory_has_step(f, "test-check-flang", hasarg = "env", contains = EXPECTED_ENV)
+assert factory_has_step(f, "test-libunwind")
+assert factory_has_step(f, "test-libunwind", hasarg = 'command')
+assert factory_has_step(f, "test-libunwind", hasarg = "env", contains = EXPECTED_ENV)
+#TODO: Transforom rendering is currently unsupported to check the step name.
+#assert factory_has_step(f, "install")
+
+# Specify Visual Studio configuration.
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(vs = "autodetect")
+print(f"factory with VS environment autodetect: {f}\n")
+
+assert factory_has_num_steps(f, 8)
+assert factory_has_step(f, "set-pros.vs_env")
+
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(vs = "manual", vs_arch = "amd64")
+print(f"factory with VS environment manual: {f}\n")
+
+assert factory_has_num_steps(f, 8)
+assert factory_has_step(f, "set-pros.vs_env")
+
+# Check custom CMake generator
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(generator = "Unix Makefiles")
+print(f"factory with CMake generator: {f}\n")
+
+assert factory_has_step(f, "cmake-configure", hasarg = "generator", contains = "Unix Makefiles")
+
+# Check custom CMake definitions and options.
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(allow_cmake_defaults = False)
+print(f"No CMake defaults: {f}\n")
+
+assert factory_has_step(f, "cmake-configure", hasarg = "definitions", contains = {
+                                                                        'LLVM_ENABLE_PROJECTS'          : 'llvm',
+                                                                    })
+
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(
+        cmake_definitions = {
+            # Override defaults.
+            'CMAKE_BUILD_TYPE'              : 'Debug',
+            # Custom extra definitions.
+            'LLVM_TARGETS_TO_BUILD'         : 'all',
+            'CMAKE_EXPORT_COMPILE_COMMANDS' : '1',
+
+        },
+        cmake_options = [
+            "-C", "%(prop:srcdir_relative)s/clang/cmake/caches/CrossWinToARMLinux.cmake"
+        ],
+        allow_cmake_defaults = True
+    )
+print(f"Custom CMake definitions/options (1): {f}\n")
+
+assert factory_has_step(f, "cmake-configure", hasarg = "definitions", contains = {
+                                                                        'LLVM_ENABLE_PROJECTS'          : 'llvm',
+                                                                        'CMAKE_BUILD_TYPE'              : 'Debug',
+                                                                        'LLVM_ENABLE_ASSERTIONS'        : 'ON',
+                                                                        'LLVM_LIT_ARGS'                 : '-v --time-tests',
+                                                                        # Custom extra definitions.
+                                                                        'LLVM_TARGETS_TO_BUILD'         : 'all',
+                                                                        'CMAKE_EXPORT_COMPILE_COMMANDS' : '1',
+                                                                    })
+assert factory_has_step(f, "cmake-configure", hasarg = "options", contains = [
+                                                                        "-C", "%(prop:srcdir_relative)s/clang/cmake/caches/CrossWinToARMLinux.cmake"
+                                                                    ])
+# without defaults  (allow_cmake_defaults = False)
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(
+        cmake_definitions = {
+            'CMAKE_BUILD_TYPE'              : 'Debug',
+            'LLVM_TARGETS_TO_BUILD'         : 'all',
+            'CMAKE_EXPORT_COMPILE_COMMANDS' : '1',
+
+        },
+        allow_cmake_defaults = False
+    )
+print(f"Custom CMake definitions/options (1): {f}\n")
+
+assert factory_has_step(f, "cmake-configure", hasarg = "definitions", contains = {
+                                                                        'LLVM_ENABLE_PROJECTS'          : 'llvm',
+                                                                        'CMAKE_BUILD_TYPE'              : 'Debug',
+                                                                        'LLVM_TARGETS_TO_BUILD'         : 'all',
+                                                                        'CMAKE_EXPORT_COMPILE_COMMANDS' : '1',
+                                                                    })
+
+# Check the step extensions.
+
+cbf = LLVMBuildFactory()
+cbf.addStep(
+    steps.SetProperty(
+        name = "pre_configure_step",
+        property = "SomeProperty",
+        value = "SomeValue"
+    )
+)
+
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(
+        # Force adding a default installation target step.
+        install_dir = "install-staged",
+        pre_configure_steps = cbf,    # Single step within the build factory
+        post_build_steps = [
+            steps.SetProperty(
+                name = "post_build_step1",
+                property = "SomeProperty",
+                value = "SomeValue"
+            ),
+            steps.ShellCommand(
+                name = "post_build_step2",
+                command = ["ls"],
+            ),
+        ],
+        pre_install_steps = [
+            steps.SetProperty(
+                name = "pre_install_step",
+                property = "SomeProperty",
+                value = "SomeValue"
+            ),
+        ],
+        post_finalize_steps =[
+            steps.SetProperty(
+                name = "post_finalize_step",
+                property = "SomeProperty",
+                value = "SomeValue"
+            ),
+        ],
+    )
+print(f"Step Extendions: {f}")
+
+assert factory_has_num_steps(f, 9 + 5)
+
+assert factory_has_step(f, "pre_configure_step", hasarg = "property", contains = "SomeProperty")
+assert factory_has_step(f, "post_build_step1", hasarg = "property", contains = "SomeProperty")
+assert factory_has_step(f, "post_build_step2", hasarg = "command", contains = ["ls"])
+assert factory_has_step(f, "pre_install_step", hasarg = "property", contains = "SomeProperty")
+assert factory_has_step(f, "post_finalize_step", hasarg = "property", contains = "SomeProperty")

--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -1,5 +1,9 @@
+# UnifiedTreeBuilder.py
+#
+
 from buildbot.plugins import steps, util
 from buildbot.steps.shell import SetPropertyFromCommand
+from buildbot.process.factory import BuildFactory
 
 from zorg.buildbot.commands.CmakeCommand import CmakeCommand
 from zorg.buildbot.commands.NinjaCommand import NinjaCommand
@@ -586,5 +590,458 @@ def getCmakeWithNinjaMultistageBuildFactory(
            env=merged_env,
            stage_name=stage_names[stage_idx],
            **kwargs)
+
+    return f
+
+
+def getCmakeExBuildFactory(
+        depends_on_projects = None,
+        enable_runtimes = "auto",
+        cmake_definitions = None,
+        cmake_options = None,
+        allow_cmake_defaults = True,    # Add default CMake definitions to build LLVM project (if not specified).
+        targets = ".",
+        install_targets = "install",
+        checks = "check-all",
+        checks_on_target = None,
+        generator = "Ninja",            # CMake generator.
+        vs = None,                      # VS tools environment variable if using MSVC.
+        vs_arch = None,
+        clean = False,                  # Do clean build flag.
+        extra_git_args = None,          # Extra parameters for steps.Git step (such as 'config', 'workdir', etc.)
+        llvm_srcdir = None,             # A custom LLVM src directory within %(prop:builddir)s of the builder.
+        src_to_build_dir = None,
+        obj_dir = None,
+        install_dir = None,
+        pre_configure_steps = None,
+        post_build_steps = None,
+        pre_install_steps = None,
+        post_finalize_steps = None,
+        jobs = None,                    # Restrict a degree of parallelism.
+        env  = None,                    # Common environmental variables.
+    ):
+
+    """ Create and configure a builder factory to build a LLVM project from the unified source tree.
+
+        This is one-stage CMake configurable build that uses Ninja generator by default. Using the other CMake generators
+        also possible.
+
+        Property Parameters
+        -------------------
+
+        clean : boolean
+            Clean up the source and the build folders.
+
+        clean_obj : boolean
+            Clean up the build folders.
+
+
+        Parameters
+        ----------
+
+        depends_on_projects : list, optional
+            A list of LLVM projects this builder depends on (default is None).
+
+            These project names will be used to set up the proper schedulers. Also these names will be used
+            to prepare the factory's 'enable_projects' and 'enable_runtimes' lists.
+
+            If this parameter is not None and contains the non-runtime project names, they will go to
+            LLVM_ENABLE_PROJECTS CMake configuration parameter.
+
+        enable_runtimes : list, optional
+            A list of the runtime project names for the build (default is 'auto'). This list goes into
+            the factory's 'enable_runtimes' attribute and LLVM_ENABLE_RUNTIMES CMake configuration parameter.
+
+            If "auto" is specified, the runtime projects will be extracted from 'depends_on_projects' parameter.
+
+            If None is specified, LLVM_ENABLE_RUNTIMES will not be set for the CMake configuration step.
+
+            (see LLVMBuildFactory for more details).
+
+        cmake_definitions : dict, optional
+            A dictionary of the CMake definitions (default is None).
+
+        cmake_options : list, optional
+            A list of the CMake options (default is None).
+
+        allow_cmake_defaults : boolean
+            Add default CMake definitions to the build configuration step (default True).
+
+            A default value will be used only if a definition is not explicitly specified in 'cmake_definitions'
+            argument and allow_cmake_defaults evaluates to True.
+
+        targets : list, optional
+            A list of targets to build (default is ["."]).
+            Each target gets built in a separate step, skipped if None.
+
+            Pass string '.' in a list to build the default target.
+
+        install_targets : list, optional
+            A list of the installation targets (default is ["install"]).
+
+            Each target gets installed in a separate step.
+
+            NOTE: 'install_dir' argument must be specified if there are install_targets.
+
+        checks : list, optional
+            A list of the check targets (default is ["check-all"]).
+
+            Each check target gets executed in a separate step. The check step uses LitTestCommand
+            to parse and display the test result logs.
+
+            No check steps will be generated for the build if 'None' was provided with this argument.
+
+        checks_on_target : list of tuples, optional
+            A list of commands to run the tests on the remote dev boards (default is None).
+
+            This argument expects a list of tuples with test names to display and the test commands to execute.
+            For example:
+            ```
+            checks_on_target=[
+                ("libunwind",
+                    ["python", "bin/llvm-lit.py", "-v", "--time-tests", "--threads=32",
+                     "runtimes/runtimes-armv7-unknown-linux-gnueabihf-bins/libunwind/test"]
+                ),
+                ...
+            ]
+            ```
+
+        generator : str, required
+            CMake generator (default is 'Ninja').
+
+            See CMake documentation for more details.
+
+        vs : str, optional
+            Set up Visual Studio environment for the build (default is None).
+
+            Possible values are "autodetect", "manual" or None.
+
+        vs_arch : str, optional
+            Provide a build host arch for the Visual Studio tools (default is None)
+
+            Possible values are None, "amd64", "x64", etc. Please see Visual Studio documentation for more details.
+
+        clean : boolean
+            Alsways do a clean build (default is False).
+
+        extra_git_args : dict, optional
+            Provide extra arguments for the Git step (default is None).
+
+            Sometimes it is necessary to pass some additional parameters to the git step, such as
+            'config', 'workdir', etc.
+
+        llvm_srcdir : str, optional
+            A custom LLVM src directory within %(prop:builddir)s of the builder (default is "llvm-project").
+
+            (see LLVMBuildFactory for more details).
+
+        src_to_build_dir : str, optional
+            A specific root project directory within the LLVM source code to configure and build (default is "llvm").
+
+            Provide a relative path to sub-project within the llvm-project directory to start configuring with instead of
+            default llvm folder.
+
+            For example: pass "flang/runtime" to configure and build the Flang runtime sub-project.
+
+            (see LLVMBuildFactory for more details).
+
+        obj_dir : str, optional
+            The build folder (default is "build").
+
+            (see LLVMBuildFactory for more details).
+
+        install_dir : str, optional
+            The installation folder (default is None).
+
+            Provide the installation folder and the install targets to add the installation steps to the final build.
+
+        pre_configure_steps : list or LLVMFactory, optional
+            The buildflow customization steps to execute before the CMake configuration step.
+
+            Provide a list of build step objects or LLVMFactory object.
+
+        post_build_steps : list or LLVMFactory, optional
+            The buildflow customization steps to execute after the build step, but before the check steps.
+
+            Provide a list of build step objects or LLVMFactory object.
+
+        pre_install_steps : list or LLVMFactory, optional
+            The buildflow customization steps to execute after the check steps, but before the installation steps (if requested).
+
+            Provide a list of build step objects or LLVMFactory object.
+
+        post_finalize_steps : list or LLVMFactory, optional
+            The buildflow customization steps to execute at the end of the build workflow.
+
+            Provide a list of build step objects or LLVMFactory object.
+
+        jobs : int, optional
+            Restrict a degree of parallelism (default is None).
+
+        env : dict, optional
+            Common environmental variables for all build steps (default is None).
+
+
+        Returns
+        -------
+
+        Returns the factory object with prepared build steps.
+
+        Properties
+        ----------
+
+        The factory sets some properties to provide more flexible configuration for the builders:
+
+        srcdir
+            Relative path to the source code root directory ("llvm-project" by default).
+
+            "%(prop:builddir)s/%(prop:srcdir)s" is a fully qualified path to the source code dir.
+
+        srcdir_relative
+            Path to the source code root directory relative to the objdir ("../llvm-project" by default).
+
+        objdir
+            Relative path to the build directory.
+
+            "%(prop:builddir)s/%(prop:objdir)s" is a fully qualified path to the obj dir.
+
+        depends_on_projects
+            A list of LLVM projects this builder depends on. It will build commits to these projects.
+
+        enable_projects
+            A list of enabled projects.
+
+        enable_runtimes
+            A list of enabled runtimes.
+
+    """
+    assert generator, "CMake generator must be specified."
+    assert not pre_configure_steps or isinstance(pre_configure_steps, (list, BuildFactory)), \
+                                                 "The 'pre_configure_steps' argument must be a list() or BuildFactory()."
+    assert not post_build_steps or isinstance(post_build_steps, (list, BuildFactory)), \
+                                                 "The 'post_build_steps' argument must be a list() or BuildFactory()."
+    assert not pre_install_steps or isinstance(pre_install_steps, (list, BuildFactory)), \
+                                                 "The 'pre_install_steps' argument must be a list() or BuildFactory()."
+    assert not post_finalize_steps or isinstance(post_finalize_steps, (list, BuildFactory)), \
+                                                 "The 'post_finalize_steps' argument must be a list() or BuildFactory()."
+
+    # This function extends the current workflow with provided custom steps.
+    def extend_with_custom_steps(fc, s):
+        # We already got either list() or LLVMBuildFactory() object here.
+        fc.addSteps(s.steps if isinstance(s, BuildFactory) else s)
+
+    def norm_target_list_arg(lst):
+        if type(lst) == str:
+            lst = list(filter(None, lst.split(";")))
+        # In case we got IRenderable, just wrap it into the list.
+        if not isinstance(lst, list):
+            lst = [ lst ]
+        return lst
+
+    # Normalize all arguments with a list of the targets.
+    # We need to convert them into the regular lists of str/IRenderable objects or empty list.
+    targets = norm_target_list_arg(targets or [])
+    install_targets = norm_target_list_arg(install_targets or [])
+    checks = norm_target_list_arg(checks or [])
+    checks_on_target = checks_on_target or []
+
+    env = env or {}
+    # Do not everride TERM just in case.
+    if not "TERM" in env:
+        # Be cautious and disable color output from all tools.
+        env.update({ 'TERM' : 'dumb' })
+
+    if not "NINJA_STATUS" in env and generator.upper() == "NINJA":
+        env.update({ 'NINJA_STATUS' : "%e [%u/%r/%f] " })
+
+    # Default root factory. We will collect all steps for all stages here.
+    f = LLVMBuildFactory(
+            depends_on_projects = depends_on_projects,
+            enable_runtimes     = enable_runtimes,
+            llvm_srcdir         = llvm_srcdir,
+            src_to_build_dir    = src_to_build_dir,
+            obj_dir             = obj_dir,
+            install_dir         = install_dir,
+        )
+
+    f.addSteps([
+        # Set up some properties, which could be used to configure the builders.
+        steps.SetProperties(
+            name            = 'set-props',
+            properties      = {
+                "depends_on_projects"   : ";".join(sorted(f.depends_on_projects)),
+                "enable_projects"       : ";".join(sorted(f.enable_projects)),
+                "enable_runtimes"       : ";".join(sorted(f.enable_runtimes)),
+                "srcdir"                : util.Interpolate(f.monorepo_dir),
+                "srcdir_relative"       : util.Interpolate(LLVMBuildFactory.pathRelativeTo(f.monorepo_dir, f.obj_dir)),
+                "objdir"                : util.Interpolate(f.obj_dir),
+            }
+        ),
+        # Remove the source code for a clean checkout if requested by property.
+        steps.RemoveDirectory(
+            name            = 'clean-src-dir',
+            dir             = util.Interpolate(f.monorepo_dir),
+            description     = ["Remove", util.Interpolate(f.monorepo_dir), "directory"],
+            haltOnFailure   = False,
+            flunkOnFailure  = False,
+            doStepIf        = util.Property("clean", False) == True,
+        ),
+
+        # This is an incremental build, unless otherwise has been requested.
+        # Remove obj dirs for a clean build.
+        steps.RemoveDirectory(
+            name            = 'clean-obj-dir',
+            dir             = util.Interpolate(f.obj_dir),
+            description     = ["Remove", util.Interpolate(f.obj_dir), "directory"],
+            haltOnFailure   = False,
+            flunkOnFailure  = False,
+            doStepIf        = lambda step, clean = clean: clean or step.getProperty("clean_obj") == True
+        ),
+    ])
+
+    # Let's start from getting the source code. We share it between all stages.
+
+    # Add the Git step.
+    extra_git_args = extra_git_args or {}
+
+    f.addGetSourcecodeSteps(**extra_git_args)
+
+    # Add custom pre-configuration steps if specified.
+    if pre_configure_steps:
+        extend_with_custom_steps(f, pre_configure_steps)
+
+    # Configure MSVC environment if requested.
+    if vs:
+        f.addStep(
+            steps.SetPropertyFromCommand(
+                name            = "set-props.vs_env",
+                command         = builders_util.getVisualStudioEnvironment(vs, vs_arch),
+                extract_fn      = builders_util.extractVSEnvironment,
+                env             = env
+            ))
+        env = util.Property('vs_env')
+
+    # Build the CMake command definitions.
+    cmake_definitions = cmake_definitions or dict()
+    assert isinstance(cmake_definitions, dict), "The CMake definitions argument must be a dictionary."
+    cmake_options = cmake_options or list()
+    assert isinstance(cmake_options, list), "The CMake options argument must be a list."
+
+    if not "LLVM_ENABLE_PROJECTS" in cmake_definitions and f.enable_projects:
+        cmake_definitions.update({ "LLVM_ENABLE_PROJECTS" : ";".join(sorted(f.enable_projects)) })
+
+    if not "LLVM_ENABLE_RUNTIMES" in cmake_definitions and f.enable_runtimes:
+        cmake_definitions.update({ "LLVM_ENABLE_RUNTIMES" : ";".join(sorted(f.enable_runtimes)) })
+
+    if not "CMAKE_INSTALL_PREFIX" in cmake_definitions and f.install_dir:
+        cmake_definitions.update({ "CMAKE_INSTALL_PREFIX" : LLVMBuildFactory.pathRelativeTo(
+                                                                f.install_dir,
+                                                                f.obj_dir) })
+        # Remove install directory.
+        f.addSteps([
+            steps.RemoveDirectory(
+                name            = f"clean-install-dir",
+                dir             = util.Interpolate(f.install_dir),
+                description     = ["Remove", util.Interpolate(f.install_dir), "directory"],
+                haltOnFailure   = False,
+                flunkOnFailure  = False,
+                doStepIf        = lambda step, clean = clean: clean or step.getProperty("clean_obj") == True
+            ),
+        ])
+
+    # Set proper defaults.
+    if allow_cmake_defaults:
+        if not "CMAKE_BUILD_TYPE" in cmake_definitions:
+            cmake_definitions.update({ "CMAKE_BUILD_TYPE" : "Release" })
+        if not "LLVM_ENABLE_ASSERTIONS" in cmake_definitions:
+            cmake_definitions.update({ "LLVM_ENABLE_ASSERTIONS" : "ON" })
+        if not "LLVM_LIT_ARGS" in cmake_definitions and checks:
+            cmake_definitions.update({ "LLVM_LIT_ARGS" : "-v --time-tests" })
+
+    f.addStep(
+        steps.CMake(
+            name            = f"cmake-configure",
+            path            = LLVMBuildFactory.pathRelativeTo(f.llvm_srcdir, f.obj_dir),
+            generator       = generator,
+            definitions     = cmake_definitions,
+            options         = cmake_options,
+            description     = ["CMake configure"],
+            haltOnFailure   = True,
+            env             = env,
+            workdir         = f.obj_dir
+        ))
+
+    # Build Commands.
+    #NOTE: please note that the default target (.) cannot be specified by the IRenderable object.
+    for target in targets:
+        cmake_build_options = ["--build", "."]
+        if target != ".":
+            cmake_build_options.extend(["--target", target])
+        if jobs:
+            cmake_build_options.extend(["--", "-j", jobs])
+
+        target_title = "default" if target == "." else target
+
+        f.addStep(
+            steps.CMake(
+                name            = util.Interpolate("build-%(kw:title)s", title = target_title),
+                options         = cmake_build_options,
+                description     = ["Build target", target_title],
+                haltOnFailure   = True,
+                env             = env,
+                workdir         = f.obj_dir
+            ))
+
+    # Add the custom post-build workflow extension steps, if specified.
+    if post_build_steps:
+        extend_with_custom_steps(f, post_build_steps)
+
+    # Check Commands.
+    for target in checks:
+        f.addStep(
+            LitTestCommand(
+                name            = util.Interpolate("test-%(kw:title)s", title = target),
+                command         = [steps.CMake.DEFAULT_CMAKE, "--build", ".", "--target", target],
+                description     = ["Test just built components:", target],
+                descriptionDone = ["Test just built components:", target, "completed"],
+                haltOnFailure   = False, # We want to test as much as we could.
+                env             = env,
+                workdir         = f.obj_dir
+            ))
+
+    # Target Check Commands.
+    for target, cmd in checks_on_target:
+        f.addStep(
+            LitTestCommand(
+                name            = util.Interpolate("test-%(kw:title)s", title = target),
+                command         = cmd,
+                description     = ["Test just built components:", target],
+                descriptionDone = ["Test just built components:", target, "completed"],
+                haltOnFailure   = False, # We want to test as much as we could.
+                env             = env,
+                workdir         = f.obj_dir
+            ))
+
+    # Add the custom pre-installation workflow extension steps, if specified.
+    if pre_install_steps:
+        extend_with_custom_steps(f, pre_install_steps)
+
+    # Process the installation targets.
+    if f.install_dir and install_targets:
+        for target in install_targets:
+            f.addStep(
+                steps.CMake(
+                    name            = util.Transform(lambda s: s if s.startswith("install") else f"install-{s}",
+                                                     util.Interpolate("%(kw:title)s", title = target)),
+                    options         = ["--build", ".", "--target", target],
+                    description     = ["Install just built components:", target],
+                    haltOnFailure   = False,
+                    env             = env,
+                    workdir         = f.obj_dir
+                ))
+
+    # Add the custom finalize workflow extension steps, if specified.
+    if post_finalize_steps:
+        extend_with_custom_steps(f, post_finalize_steps)
 
     return f


### PR DESCRIPTION
Added new build factory UnifiedTreeBuilder.getCmakeExBuildFactory().
The factory supports the latest Buildbot's CMake command build steps and
its format of arguments.

This factory is a replacement for the following factories:
* UnifiedTreeBuilder.getCmakeBuildFactory()
* UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory()
* UnifiedTreeBuilder.getCmakeWithNinjaWithMSVCBuildFactory()
* XToolchainBuilder.getCmakeWithMSVCBuildFactory()
